### PR TITLE
Add log sanitizer to auto-mask secrets

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+ai-sessions-*.md

--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -5,6 +5,7 @@ import { Headers } from "node-fetch";
 import OpenAPIClientAxios from "openapi-client-axios";
 import type { OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
 import { isFileUploadParameter } from "../openapi/file-upload";
+import { sanitize } from "../utils/sanitizer";
 
 export type HttpClientConfig = {
   baseUrl: string;
@@ -53,7 +54,7 @@ export class HttpClient {
     operation: OpenAPIV3.OperationObject,
     params: Record<string, any>,
   ): Promise<FormData | null> {
-    console.error("prepareFileUpload", { operation, params });
+    console.error(...sanitize("prepareFileUpload", { operation, params }));
     const fileParams = isFileUploadParameter(operation);
     if (fileParams.length === 0) return null;
 
@@ -61,7 +62,7 @@ export class HttpClient {
 
     // Handle file uploads
     for (const param of fileParams) {
-      console.error(`extracting ${param}`, { params });
+      console.error(...sanitize(`extracting ${param}`, { params }));
       const filePath = params[param];
       if (!filePath) {
         throw new Error(`File path must be provided for parameter: ${param}`);
@@ -168,7 +169,7 @@ export class HttpClient {
       };
 
       // first argument is url parameters, second is body parameters
-      console.error("calling operation", { operationId, urlParameters, bodyParams, requestConfig });
+      console.error(...sanitize("calling operation", { operationId, urlParameters, bodyParams, requestConfig }));
       const response = await operationFn(urlParameters, hasBody ? bodyParams : undefined, requestConfig);
 
       console.error("operation finished");
@@ -185,7 +186,7 @@ export class HttpClient {
       };
     } catch (error: any) {
       if (error.response) {
-        console.error("Error in http client", error);
+        console.error(...sanitize("Error in http client", error));
         const headers = new Headers();
         Object.entries(error.response.headers).forEach(([key, value]) => {
           if (value) headers.append(key, value.toString());

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -7,6 +7,7 @@ import { OpenAPIV3 } from "openapi-types";
 import { HttpClient, HttpClientError } from "../client/http-client";
 import { OpenAPIToMCPConverter } from "../openapi/parser";
 import { determineBaseUrl } from "../utils/base-url";
+import { registerSecrets, sanitize } from "../utils/sanitizer";
 
 type PathItemObject = OpenAPIV3.PathItemObject & {
   get?: OpenAPIV3.OperationObject;
@@ -74,12 +75,12 @@ export class MCPProxy {
 
     // Handle tool calling
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      console.error("calling tool", request.params);
+      console.error(...sanitize("calling tool", request.params));
       const { name, arguments: params } = request.params;
 
       // Find the operation in OpenAPI spec
       const operation = this.findOperation(name);
-      console.error("operations", this.openApiLookup);
+      console.error(...sanitize("operations", this.openApiLookup));
       if (!operation) {
         throw new Error(`Method ${name} not found`);
       }
@@ -98,9 +99,9 @@ export class MCPProxy {
           ],
         };
       } catch (error) {
-        console.error("Error in tool call", error);
+        console.error(...sanitize("Error in tool call", error));
         if (error instanceof HttpClientError) {
-          console.error("HttpClientError encountered, returning structured error", error);
+          console.error(...sanitize("HttpClientError encountered, returning structured error", error));
           const data = error.data?.response?.data ?? error.data ?? {};
           return {
             content: [
@@ -135,6 +136,7 @@ export class MCPProxy {
         console.warn("OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:", typeof headers);
         return {};
       }
+      registerSecrets(headers);
       return headers;
     } catch (error) {
       console.warn("Failed to parse OPENAPI_MCP_HEADERS environment variable:", error);

--- a/src/utils/__tests__/sanitizer.test.ts
+++ b/src/utils/__tests__/sanitizer.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearSecrets, registerSecret, registerSecrets, sanitize } from "../sanitizer";
+
+describe("sanitizer", () => {
+  afterEach(() => {
+    clearSecrets();
+  });
+
+  describe("masking strategy", () => {
+    it("masks long secrets (>= 8 chars) showing first 4 and last 4", () => {
+      registerSecret("abcd1234efgh");
+      const [result] = sanitize("token is abcd1234efgh here");
+      expect(result).toBe("token is abcd****efgh here");
+    });
+
+    it("fully masks short secrets (< 8 chars)", () => {
+      registerSecret("short");
+      const [result] = sanitize("secret: short");
+      expect(result).toBe("secret: ****");
+    });
+
+    it("masks exactly 8 char secrets with partial reveal", () => {
+      registerSecret("12345678");
+      const [result] = sanitize("key=12345678");
+      expect(result).toBe("key=1234****5678");
+    });
+
+    it("ignores empty strings", () => {
+      registerSecret("");
+      const [result] = sanitize("nothing to mask");
+      expect(result).toBe("nothing to mask");
+    });
+  });
+
+  describe("registerSecrets", () => {
+    it("registers all values from a headers object", () => {
+      registerSecrets({
+        Authorization: "Bearer mytoken1234",
+        "X-Custom": "secretvalue!",
+      });
+      const [result] = sanitize("Bearer mytoken1234 and secretvalue!");
+      expect(result).toBe("Bear****1234 and secr****lue!");
+    });
+  });
+
+  describe("sanitize", () => {
+    it("passes through primitives when no secrets registered", () => {
+      const result = sanitize("hello", 42, true, null, undefined);
+      expect(result).toEqual(["hello", 42, true, null, undefined]);
+    });
+
+    it("passes through primitives unchanged even with secrets", () => {
+      registerSecret("something");
+      const result = sanitize(42, true, null, undefined);
+      expect(result).toEqual([42, true, null, undefined]);
+    });
+
+    it("sanitizes multiple arguments", () => {
+      registerSecret("supersecret1");
+      const result = sanitize("first supersecret1", "second supersecret1");
+      expect(result).toEqual(["first supe****ret1", "second supe****ret1"]);
+    });
+
+    it("sanitizes nested objects", () => {
+      registerSecret("my-api-key-value");
+      const obj = {
+        config: {
+          headers: {
+            Authorization: "Bearer my-api-key-value",
+          },
+          nested: {
+            deep: "contains my-api-key-value inside",
+          },
+        },
+      };
+      const [result] = sanitize(obj);
+      expect(result).toEqual({
+        config: {
+          headers: {
+            Authorization: "Bearer my-a****alue",
+          },
+          nested: {
+            deep: "contains my-a****alue inside",
+          },
+        },
+      });
+    });
+
+    it("sanitizes arrays within objects", () => {
+      registerSecret("tokentokentoken");
+      const obj = { items: ["tokentokentoken", "safe", "also tokentokentoken"] };
+      const [result] = sanitize(obj) as [any];
+      expect(result.items).toEqual(["toke****oken", "safe", "also toke****oken"]);
+    });
+
+    it("sanitizes Error objects", () => {
+      registerSecret("leaked-secret!");
+      const error = new Error("Request failed with leaked-secret! in body");
+      const [result] = sanitize(error) as [any];
+      expect(result.name).toBe("Error");
+      expect(result.message).toBe("Request failed with leak****ret! in body");
+      expect(result.stack).toBeDefined();
+      expect(result.stack).not.toContain("leaked-secret!");
+    });
+
+    it("preserves extra properties on Error subclasses", () => {
+      registerSecret("errortoken1234");
+      class CustomError extends Error {
+        data: any;
+        constructor(msg: string, data: any) {
+          super(msg);
+          this.name = "CustomError";
+          this.data = data;
+        }
+      }
+      const error = new CustomError("fail with errortoken1234", { detail: "has errortoken1234" });
+      const [result] = sanitize(error) as [any];
+      expect(result.name).toBe("CustomError");
+      expect(result.message).not.toContain("errortoken1234");
+      expect(result.data.detail).not.toContain("errortoken1234");
+    });
+
+    it("does not mutate original objects", () => {
+      registerSecret("donottouchme!");
+      const original = { key: "donottouchme!" };
+      sanitize(original);
+      expect(original.key).toBe("donottouchme!");
+    });
+
+    it("handles circular references gracefully", () => {
+      registerSecret("circular-secret");
+      const obj: any = { a: "circular-secret" };
+      obj.self = obj;
+      const [result] = sanitize(obj);
+      expect(result).toBe("[unserializable]");
+    });
+
+    it("handles multiple secrets in the same string", () => {
+      registerSecret("firstsecret!");
+      registerSecret("secondsecret");
+      const [result] = sanitize("has firstsecret! and secondsecret in it");
+      expect(result).not.toContain("firstsecret!");
+      expect(result).not.toContain("secondsecret");
+    });
+
+    it("handles JSON-escaped variants of secrets", () => {
+      const secretWithQuote = 'secret"with"quotes';
+      registerSecret(secretWithQuote);
+      const jsonStr = JSON.stringify({ token: secretWithQuote });
+      const [result] = sanitize(jsonStr);
+      expect(result).not.toContain(secretWithQuote);
+      // Also check the JSON-escaped version is masked
+      expect(result).not.toContain('secret\\"with\\"quotes');
+    });
+  });
+
+  describe("clearSecrets", () => {
+    it("removes all registered secrets", () => {
+      registerSecret("clearthis123");
+      clearSecrets();
+      const [result] = sanitize("clearthis123 should remain");
+      expect(result).toBe("clearthis123 should remain");
+    });
+  });
+});

--- a/src/utils/sanitizer.ts
+++ b/src/utils/sanitizer.ts
@@ -1,0 +1,83 @@
+/**
+ * Log sanitizer that auto-masks registered secrets in log output.
+ */
+
+const secrets = new Map<string, string>();
+
+function maskValue(value: string): string {
+  if (value.length >= 8) {
+    return value.slice(0, 4) + "****" + value.slice(-4);
+  }
+  return "****";
+}
+
+export function registerSecret(value: string): void {
+  if (!value) return;
+  const masked = maskValue(value);
+  secrets.set(value, masked);
+  // Also register JSON-escaped variant for secrets inside JSON.stringify output
+  const jsonEscaped = JSON.stringify(value).slice(1, -1);
+  if (jsonEscaped !== value) {
+    secrets.set(jsonEscaped, masked);
+  }
+}
+
+export function registerSecrets(headers: Record<string, string>): void {
+  for (const value of Object.values(headers)) {
+    if (typeof value === "string") {
+      registerSecret(value);
+    }
+  }
+}
+
+export function clearSecrets(): void {
+  secrets.clear();
+}
+
+function sanitizeString(str: string): string {
+  let result = str;
+  for (const [raw, masked] of secrets) {
+    if (result.includes(raw)) {
+      result = result.split(raw).join(masked);
+    }
+  }
+  return result;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return sanitizeString(value);
+  if (typeof value === "number" || typeof value === "boolean") return value;
+
+  if (value instanceof Error) {
+    const sanitized: Record<string, unknown> = {
+      name: value.name,
+      message: sanitizeString(value.message),
+    };
+    if (value.stack) {
+      sanitized.stack = sanitizeString(value.stack);
+    }
+    // Preserve extra properties (e.g. HttpClientError.data)
+    for (const key of Object.keys(value)) {
+      if (!(key in sanitized)) {
+        sanitized[key] = sanitizeValue((value as any)[key]);
+      }
+    }
+    return sanitized;
+  }
+
+  // Objects and arrays: JSON round-trip for safe deep copy + sanitization
+  try {
+    const json = JSON.stringify(value);
+    const sanitizedJson = sanitizeString(json);
+    return JSON.parse(sanitizedJson);
+  } catch {
+    // Circular refs or other serialization failures — return placeholder
+    return "[unserializable]";
+  }
+}
+
+export function sanitize(...args: unknown[]): unknown[] {
+  if (secrets.size === 0) return args;
+  return args.map(sanitizeValue);
+}


### PR DESCRIPTION
## Summary
- Adds `src/utils/sanitizer.ts` — lightweight utility that registers secrets from parsed headers and masks them in log output (first 4 + `****` + last 4 for secrets >= 8 chars, full `****` for shorter)
- Wraps all 8 high-risk `console.error` calls in `proxy.ts` and `http-client.ts` with `sanitize()` to prevent accidental leakage of auth tokens and API keys to stderr
- Includes 17 tests covering masking strategy, nested objects, Error objects, circular refs, no-mutation guarantee, and JSON-escaped variants

## Test plan
- [x] `npm test` — all 104 tests pass (including 17 new sanitizer tests)
- [x] `npm run typecheck` — no type errors
- [x] `npm run lint` — no lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)