### PR TITLE
feat: load credentials from config file

### DIFF
--- a/src/auth/get-key.ts
+++ b/src/auth/get-key.ts
@@ -1,9 +1,8 @@
 import axios from "axios";
 import * as readline from "readline";
+import { CREDENTIALS_PATH, saveCredentials } from "../config/credentials";
 
-interface AuthToken {
-  app_key: string;
-}
+const ANYTYPE_VERSION = "2025-11-08";
 
 export class AppKeyGenerator {
   private readonly rl: readline.Interface;
@@ -51,9 +50,11 @@ export class AppKeyGenerator {
    */
   private async startAuthentication(): Promise<string> {
     try {
-      const response = await axios.post(`${this.basePath}/v1/auth/display_code`, null, {
-        params: { app_name: this.appName },
-      });
+      const response = await axios.post(
+        `${this.basePath}/v1/auth/challenges`,
+        { app_name: this.appName },
+        { headers: { "Anytype-Version": ANYTYPE_VERSION } },
+      );
 
       if (!response.data?.challenge_id) {
         throw new Error("Failed to get challenge ID");
@@ -77,15 +78,18 @@ export class AppKeyGenerator {
     code: string,
   ): Promise<{ appKey: string; anytypeVersion: string }> {
     try {
-      const response = await axios.post<AuthToken>(`${this.basePath}/v1/auth/token`, null, {
-        params: { challenge_id: challengeId, code: code },
-      });
+      const response = await axios.post(
+        `${this.basePath}/v1/auth/api_keys`,
+        { challenge_id: challengeId, code },
+        { headers: { "Anytype-Version": ANYTYPE_VERSION } },
+      );
 
-      if (!response.data?.app_key) {
-        throw new Error("Authentication failed: No app key received");
+      if (!response.data?.api_key) {
+        throw new Error("Authentication failed: No API key received");
       }
 
-      return { appKey: response.data.app_key, anytypeVersion: response.headers["anytype-version"] };
+      const anytypeVersion = response.headers["anytype-version"] || ANYTYPE_VERSION;
+      return { appKey: response.data.api_key, anytypeVersion };
     } catch (error) {
       console.error("Authentication error:", error instanceof Error ? error.message : error);
       throw new Error("Failed to complete authentication");
@@ -102,6 +106,12 @@ export class AppKeyGenerator {
 
       const { appKey, anytypeVersion } = await this.completeAuthentication(challengeId, code);
       console.log("Authenticated successfully!");
+
+      // Auto-save credentials to config file
+      const baseUrl = this.basePath !== "http://127.0.0.1:31009" ? this.basePath : undefined;
+      saveCredentials({ apiKey: appKey, anytypeVersion, baseUrl });
+      console.log(`\nCredentials saved to ${CREDENTIALS_PATH}`);
+
       this.displaySuccessMessage(appKey, anytypeVersion);
     } catch (error) {
       console.error("Error:", error instanceof Error ? error.message : error);

--- a/src/config/__tests__/credentials.test.ts
+++ b/src/config/__tests__/credentials.test.ts
@@ -1,0 +1,187 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSecrets } from "../../utils/sanitizer";
+import { CREDENTIALS_PATH, loadCredentials, saveCredentials } from "../credentials";
+
+vi.mock("node:fs");
+
+describe("credentials", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.OPENAPI_MCP_HEADERS;
+    vi.clearAllMocks();
+    clearSecrets();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("CREDENTIALS_PATH", () => {
+    it("should point to ~/.config/sinh-x/anytype-mcp/credentials.json", () => {
+      expect(CREDENTIALS_PATH).toContain(path.join(".config", "sinh-x", "anytype-mcp", "credentials.json"));
+    });
+  });
+
+  describe("loadCredentials", () => {
+    it("should load headers from OPENAPI_MCP_HEADERS env var (highest priority)", () => {
+      process.env.OPENAPI_MCP_HEADERS = JSON.stringify({
+        Authorization: "Bearer env-token",
+        "Anytype-Version": "2025-11-08",
+      });
+
+      const result = loadCredentials();
+      expect(result.headers).toEqual({
+        Authorization: "Bearer env-token",
+        "Anytype-Version": "2025-11-08",
+      });
+      expect(result.baseUrl).toBeUndefined();
+    });
+
+    it("should return empty headers and warn on non-object OPENAPI_MCP_HEADERS", () => {
+      const consoleSpy = vi.spyOn(console, "warn");
+      process.env.OPENAPI_MCP_HEADERS = '"string"';
+
+      const result = loadCredentials();
+      expect(result.headers).toEqual({});
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:",
+        "string",
+      );
+    });
+
+    it("should return empty headers and warn on invalid JSON in OPENAPI_MCP_HEADERS", () => {
+      const consoleSpy = vi.spyOn(console, "warn");
+      process.env.OPENAPI_MCP_HEADERS = "invalid json";
+
+      const result = loadCredentials();
+      expect(result.headers).toEqual({});
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Failed to parse OPENAPI_MCP_HEADERS environment variable:",
+        expect.any(Error),
+      );
+    });
+
+    it("should load from credentials.json when env var is not set", () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          apiKey: "file-token",
+          anytypeVersion: "2025-11-08",
+          baseUrl: "http://custom:31009",
+        }),
+      );
+
+      const result = loadCredentials();
+      expect(result.headers).toEqual({
+        Authorization: "Bearer file-token",
+        "Anytype-Version": "2025-11-08",
+      });
+      expect(result.baseUrl).toBe("http://custom:31009");
+    });
+
+    it("should add Bearer prefix to apiKey when not present", () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ apiKey: "raw-token" }));
+
+      const result = loadCredentials();
+      expect(result.headers.Authorization).toBe("Bearer raw-token");
+    });
+
+    it("should not double-prefix apiKey that already starts with Bearer", () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ apiKey: "Bearer already-prefixed" }));
+
+      const result = loadCredentials();
+      expect(result.headers.Authorization).toBe("Bearer already-prefixed");
+    });
+
+    it("should skip Anytype-Version header when anytypeVersion is not set", () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ apiKey: "token" }));
+
+      const result = loadCredentials();
+      expect(result.headers).toEqual({ Authorization: "Bearer token" });
+      expect(result.headers["Anytype-Version"]).toBeUndefined();
+    });
+
+    it("should return empty headers when credentials.json is missing apiKey", () => {
+      const consoleSpy = vi.spyOn(console, "warn");
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anytypeVersion: "2025-11-08" }));
+
+      const result = loadCredentials();
+      expect(result.headers).toEqual({});
+      expect(consoleSpy).toHaveBeenCalledWith("credentials.json is missing required 'apiKey' field");
+    });
+
+    it("should return empty headers when credentials file does not exist", () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const result = loadCredentials();
+      expect(result.headers).toEqual({});
+      expect(result.baseUrl).toBeUndefined();
+    });
+
+    it("should return empty headers and warn on malformed credentials file", () => {
+      const consoleSpy = vi.spyOn(console, "warn");
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error("read error");
+      });
+
+      const result = loadCredentials();
+      expect(result.headers).toEqual({});
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to read credentials file:", expect.any(Error));
+    });
+
+    it("should prefer env var over config file", () => {
+      process.env.OPENAPI_MCP_HEADERS = JSON.stringify({ Authorization: "Bearer env-wins" });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ apiKey: "file-loses" }));
+
+      const result = loadCredentials();
+      expect(result.headers.Authorization).toBe("Bearer env-wins");
+      // Should not have read the file
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("saveCredentials", () => {
+    it("should create directory and write credentials file", () => {
+      saveCredentials({ apiKey: "test-key", anytypeVersion: "2025-11-08" });
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(path.dirname(CREDENTIALS_PATH), { recursive: true });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        CREDENTIALS_PATH,
+        JSON.stringify({ apiKey: "test-key", anytypeVersion: "2025-11-08" }, null, 2) + "\n",
+        "utf-8",
+      );
+    });
+
+    it("should include baseUrl when provided", () => {
+      saveCredentials({ apiKey: "test-key", anytypeVersion: "2025-11-08", baseUrl: "http://custom:31009" });
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        CREDENTIALS_PATH,
+        JSON.stringify(
+          { apiKey: "test-key", anytypeVersion: "2025-11-08", baseUrl: "http://custom:31009" },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      );
+    });
+
+    it("should omit baseUrl when not provided", () => {
+      saveCredentials({ apiKey: "test-key", anytypeVersion: "2025-11-08" });
+
+      const written = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      const parsed = JSON.parse(written);
+      expect(parsed).not.toHaveProperty("baseUrl");
+    });
+  });
+});

--- a/src/config/credentials.ts
+++ b/src/config/credentials.ts
@@ -1,0 +1,95 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { registerSecrets } from "../utils/sanitizer";
+
+export const CREDENTIALS_PATH = path.join(os.homedir(), ".config", "sinh-x", "anytype-mcp", "credentials.json");
+
+interface CredentialsFile {
+  apiKey: string;
+  anytypeVersion?: string;
+  baseUrl?: string;
+}
+
+interface LoadedCredentials {
+  headers: Record<string, string>;
+  baseUrl?: string;
+}
+
+/**
+ * Loads credentials with priority: env var OPENAPI_MCP_HEADERS > config file > empty.
+ * Registers any loaded secrets with the sanitizer.
+ */
+export function loadCredentials(): LoadedCredentials {
+  // Priority 1: OPENAPI_MCP_HEADERS env var
+  const headersJson = process.env.OPENAPI_MCP_HEADERS;
+  if (headersJson) {
+    try {
+      const headers = JSON.parse(headersJson);
+      if (typeof headers !== "object" || headers === null) {
+        console.warn("OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:", typeof headers);
+        return { headers: {} };
+      }
+      registerSecrets(headers);
+      return { headers };
+    } catch (error) {
+      console.warn("Failed to parse OPENAPI_MCP_HEADERS environment variable:", error);
+      return { headers: {} };
+    }
+  }
+
+  // Priority 2: Config file
+  try {
+    if (fs.existsSync(CREDENTIALS_PATH)) {
+      const raw = fs.readFileSync(CREDENTIALS_PATH, "utf-8");
+      const config: CredentialsFile = JSON.parse(raw);
+
+      if (!config.apiKey) {
+        console.warn("credentials.json is missing required 'apiKey' field");
+        return { headers: {} };
+      }
+
+      const headers: Record<string, string> = {};
+
+      // Handle apiKey — add "Bearer " prefix if not already present
+      headers["Authorization"] = config.apiKey.startsWith("Bearer ") ? config.apiKey : `Bearer ${config.apiKey}`;
+
+      if (config.anytypeVersion) {
+        headers["Anytype-Version"] = config.anytypeVersion;
+      }
+
+      registerSecrets(headers);
+      console.error(`Loaded credentials from ${CREDENTIALS_PATH}`);
+      return { headers, baseUrl: config.baseUrl };
+    }
+  } catch (error) {
+    console.warn("Failed to read credentials file:", error);
+  }
+
+  // Priority 3: No credentials found
+  console.warn(
+    `No credentials found. API calls will fail with 401 Unauthorized.\n` +
+      `  Option 1: Set OPENAPI_MCP_HEADERS env var with JSON headers\n` +
+      `  Option 2: Run 'anytype-mcp get-key' to authenticate and save credentials to ${CREDENTIALS_PATH}`,
+  );
+  return { headers: {} };
+}
+
+/**
+ * Saves credentials to the config file, creating the directory if needed.
+ */
+export function saveCredentials(config: { apiKey: string; anytypeVersion: string; baseUrl?: string }): void {
+  const dir = path.dirname(CREDENTIALS_PATH);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const data: CredentialsFile = {
+    apiKey: config.apiKey,
+    anytypeVersion: config.anytypeVersion,
+  };
+
+  if (config.baseUrl) {
+    data.baseUrl = config.baseUrl;
+  }
+
+  fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}

--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -3,11 +3,17 @@ import { Headers } from "node-fetch";
 import { OpenAPIV3 } from "openapi-types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HttpClient } from "../../client/http-client";
+import { loadCredentials } from "../../config/credentials";
 import { MCPProxy } from "../proxy";
 
 // Mock the dependencies
 vi.mock("../../client/http-client");
 vi.mock("@modelcontextprotocol/sdk/server/index.js");
+vi.mock("../../config/credentials", () => ({
+  loadCredentials: vi.fn(() => ({ headers: {}, baseUrl: undefined })),
+}));
+
+const mockLoadCredentials = vi.mocked(loadCredentials);
 
 describe("MCPProxy", () => {
   let proxy: MCPProxy;
@@ -139,54 +145,34 @@ describe("MCPProxy", () => {
     });
   });
 
-  describe("parseHeadersFromEnv", () => {
-    const originalEnv = process.env;
+  describe("loadCredentials integration", () => {
     const expectHeaders = (headers: Record<string, string>) => {
       expect(HttpClient).toHaveBeenCalledWith(expect.objectContaining({ headers }), expect.anything());
     };
 
-    beforeEach(() => {
-      process.env = { ...originalEnv };
-    });
-
-    afterEach(() => {
-      process.env = originalEnv;
-    });
-
-    it("should parse valid JSON headers from env", () => {
-      process.env.OPENAPI_MCP_HEADERS = JSON.stringify({
-        Authorization: "Bearer token123",
-        "X-Custom-Header": "test",
+    it("should pass headers from loadCredentials to HttpClient", () => {
+      mockLoadCredentials.mockReturnValueOnce({
+        headers: { Authorization: "Bearer token123", "X-Custom-Header": "test" },
       });
       new MCPProxy("test-proxy", mockOpenApiSpec);
       expectHeaders({ Authorization: "Bearer token123", "X-Custom-Header": "test" });
     });
 
-    it("should return empty object when env var is not set", () => {
-      delete process.env.OPENAPI_MCP_HEADERS;
+    it("should pass empty headers when loadCredentials returns none", () => {
+      mockLoadCredentials.mockReturnValueOnce({ headers: {} });
       new MCPProxy("test-proxy", mockOpenApiSpec);
       expectHeaders({});
     });
 
-    it("should return empty object and warn on invalid JSON", () => {
-      const consoleSpy = vi.spyOn(console, "warn");
-      process.env.OPENAPI_MCP_HEADERS = "invalid json";
+    it("should use baseUrl from loadCredentials when provided", () => {
+      mockLoadCredentials.mockReturnValueOnce({
+        headers: {},
+        baseUrl: "http://config-file:31009",
+      });
       new MCPProxy("test-proxy", mockOpenApiSpec);
-      expectHeaders({});
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to parse OPENAPI_MCP_HEADERS environment variable:",
-        expect.any(Error),
-      );
-    });
-
-    it("should return empty object and warn on non-object JSON", () => {
-      const consoleSpy = vi.spyOn(console, "warn");
-      process.env.OPENAPI_MCP_HEADERS = '"string"';
-      new MCPProxy("test-proxy", mockOpenApiSpec);
-      expectHeaders({});
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:",
-        "string",
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({ baseUrl: "http://config-file:31009" }),
+        expect.anything(),
       );
     });
   });

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -5,9 +5,10 @@ import { JSONSchema7 as IJsonSchema } from "json-schema";
 import { Headers } from "node-fetch";
 import { OpenAPIV3 } from "openapi-types";
 import { HttpClient, HttpClientError } from "../client/http-client";
+import { loadCredentials } from "../config/credentials";
 import { OpenAPIToMCPConverter } from "../openapi/parser";
 import { determineBaseUrl } from "../utils/base-url";
-import { registerSecrets, sanitize } from "../utils/sanitizer";
+import { sanitize } from "../utils/sanitizer";
 
 type PathItemObject = OpenAPIV3.PathItemObject & {
   get?: OpenAPIV3.OperationObject;
@@ -34,11 +35,12 @@ export class MCPProxy {
 
   constructor(name: string, openApiSpec: OpenAPIV3.Document) {
     this.server = new Server({ name, version: "1.0.0" }, { capabilities: { tools: {} } });
-    const baseUrl = determineBaseUrl(openApiSpec);
+    const { headers, baseUrl: credentialsBaseUrl } = loadCredentials();
+    const baseUrl = determineBaseUrl(openApiSpec, credentialsBaseUrl);
     this.httpClient = new HttpClient(
       {
         baseUrl,
-        headers: this.parseHeadersFromEnv(),
+        headers,
       },
       openApiSpec,
     );
@@ -122,26 +124,6 @@ export class MCPProxy {
 
   private findOperation(operationId: string): (OpenAPIV3.OperationObject & { method: string; path: string }) | null {
     return this.openApiLookup[operationId] ?? null;
-  }
-
-  private parseHeadersFromEnv(): Record<string, string> {
-    const headersJson = process.env.OPENAPI_MCP_HEADERS;
-    if (!headersJson) {
-      return {};
-    }
-
-    try {
-      const headers = JSON.parse(headersJson);
-      if (typeof headers !== "object" || headers === null) {
-        console.warn("OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:", typeof headers);
-        return {};
-      }
-      registerSecrets(headers);
-      return headers;
-    } catch (error) {
-      console.warn("Failed to parse OPENAPI_MCP_HEADERS environment variable:", error);
-      return {};
-    }
   }
 
   private getContentType(headers: Headers): "text" | "image" | "binary" {

--- a/src/utils/__tests__/base-url.test.ts
+++ b/src/utils/__tests__/base-url.test.ts
@@ -110,6 +110,28 @@ describe("base-url utilities", () => {
       expect(determineBaseUrl(mockOpenApiSpec)).toBe("http://localhost:3000");
       expect(consoleSpy).toHaveBeenCalledWith("Using base URL from OpenAPI spec: http://localhost:3000");
     });
+
+    it("should use configFileBaseUrl when env var is not set", () => {
+      const consoleSpy = vi.spyOn(console, "error");
+      delete process.env.ANYTYPE_API_BASE_URL;
+
+      expect(determineBaseUrl(mockOpenApiSpec, "http://config-file:31009")).toBe("http://config-file:31009");
+      expect(consoleSpy).toHaveBeenCalledWith("Using base URL from credentials config: http://config-file:31009");
+    });
+
+    it("should prioritize ANYTYPE_API_BASE_URL over configFileBaseUrl", () => {
+      const consoleSpy = vi.spyOn(console, "error");
+      process.env.ANYTYPE_API_BASE_URL = "http://env-var:31009";
+
+      expect(determineBaseUrl(mockOpenApiSpec, "http://config-file:31009")).toBe("http://env-var:31009");
+      expect(consoleSpy).toHaveBeenCalledWith("Using base URL from ANYTYPE_API_BASE_URL: http://env-var:31009");
+    });
+
+    it("should prioritize configFileBaseUrl over spec servers", () => {
+      delete process.env.ANYTYPE_API_BASE_URL;
+
+      expect(determineBaseUrl(mockOpenApiSpec, "http://config-file:31009")).toBe("http://config-file:31009");
+    });
   });
 
   describe("getDefaultSpecUrl", () => {

--- a/src/utils/base-url.ts
+++ b/src/utils/base-url.ts
@@ -29,10 +29,11 @@ export function parseBaseUrlFromEnv(): string | null {
 /**
  * Determines the base URL using priority order:
  * 1. ANYTYPE_API_BASE_URL environment variable
- * 2. OpenAPI spec servers[0].url
- * 3. Default fallback: http://127.0.0.1:31009
+ * 2. Config file baseUrl (if provided)
+ * 3. OpenAPI spec servers[0].url
+ * 4. Default fallback: http://127.0.0.1:31009
  */
-export function determineBaseUrl(openApiSpec?: OpenAPIV3.Document): string {
+export function determineBaseUrl(openApiSpec?: OpenAPIV3.Document, configFileBaseUrl?: string): string {
   // Priority 1: Environment variable
   const envEndpoint = parseBaseUrlFromEnv();
   if (envEndpoint) {
@@ -40,14 +41,20 @@ export function determineBaseUrl(openApiSpec?: OpenAPIV3.Document): string {
     return envEndpoint;
   }
 
-  // Priority 2: OpenAPI spec servers[0].url
+  // Priority 2: Config file baseUrl
+  if (configFileBaseUrl) {
+    console.error(`Using base URL from credentials config: ${configFileBaseUrl}`);
+    return configFileBaseUrl;
+  }
+
+  // Priority 3: OpenAPI spec servers[0].url
   const specUrl = openApiSpec?.servers?.[0]?.url;
   if (specUrl) {
     console.error(`Using base URL from OpenAPI spec: ${specUrl}`);
     return specUrl;
   }
 
-  // Priority 3: Default fallback
+  // Priority 4: Default fallback
   const defaultUrl = "http://127.0.0.1:31009";
   console.error(`Using default base URL: ${defaultUrl}`);
   return defaultUrl;


### PR DESCRIPTION
## Summary

- Add config file support (`~/.config/sinh-x/anytype-mcp/credentials.json`) so credentials load automatically without env vars
- `get-key` command auto-saves credentials after interactive auth
- Fix `get-key` to use current Anytype API auth endpoints (`/v1/auth/challenges` + `/v1/auth/api_keys`) instead of deprecated `/v1/auth/display_code` + `/v1/auth/token`
- Priority chain: env vars > config file > defaults

## Test plan

- [x] All 121 tests pass (`npm test`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Manual: `get-key` successfully authenticates and saves credentials
- [x] Manual: MCP server connects with auth using saved config file (no env vars)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)