### PR TITLE
feat: cache list-spaces at server init (#7)

### DIFF
--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -3,8 +3,9 @@ import axios from "axios";
 import fs from "node:fs";
 import path from "node:path";
 import { OpenAPIV3 } from "openapi-types";
+import { loadCredentials } from "./config/credentials";
 import { MCPProxy } from "./mcp/proxy";
-import { getDefaultSpecUrl } from "./utils/base-url";
+import { determineBaseUrl, getDefaultSpecUrl } from "./utils/base-url";
 
 export class ValidationError extends Error {
   constructor(public errors: any[]) {
@@ -47,10 +48,45 @@ export async function loadOpenApiSpec(specPath?: string): Promise<OpenAPIV3.Docu
   }
 }
 
+interface Space {
+  id: string;
+  name: string;
+}
+
+/**
+ * Prefetches spaces from the Anytype API and formats them as an instructions string.
+ * Returns undefined on failure (non-fatal).
+ */
+export async function prefetchSpaces(openApiSpec: OpenAPIV3.Document): Promise<string | undefined> {
+  try {
+    const { headers, baseUrl: credentialsBaseUrl } = loadCredentials();
+    const baseUrl = determineBaseUrl(openApiSpec, credentialsBaseUrl);
+
+    const response = await axios.get(`${baseUrl}/v1/spaces`, {
+      params: { limit: 1000 },
+      headers,
+    });
+
+    const spaces: Space[] = response.data?.data ?? response.data?.spaces ?? [];
+    if (spaces.length === 0) {
+      console.error("No spaces found during prefetch");
+      return undefined;
+    }
+
+    const spaceList = spaces.map((s) => `- "${s.name}" (id: ${s.id})`).join("\n");
+    return `Available Anytype spaces:\n${spaceList}\n\nUse the space id when calling space-scoped tools.`;
+  } catch (error: any) {
+    console.error("Failed to prefetch spaces (non-fatal):", error.message);
+    return undefined;
+  }
+}
+
 export async function initProxy(specPath: string) {
   console.error("Initializing Anytype MCP Server...");
   const openApiSpec = await loadOpenApiSpec(specPath);
-  const proxy = new MCPProxy("Anytype API", openApiSpec);
+
+  const instructions = await prefetchSpaces(openApiSpec);
+  const proxy = new MCPProxy("Anytype API", openApiSpec, instructions);
 
   await proxy.connect(new StdioServerTransport());
   console.error("Anytype MCP Server running on stdio");

--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -1,3 +1,4 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { Headers } from "node-fetch";
 import { OpenAPIV3 } from "openapi-types";
@@ -14,6 +15,7 @@ vi.mock("../../config/credentials", () => ({
 }));
 
 const mockLoadCredentials = vi.mocked(loadCredentials);
+const MockServer = vi.mocked(Server);
 
 describe("MCPProxy", () => {
   let proxy: MCPProxy;
@@ -207,6 +209,28 @@ describe("MCPProxy", () => {
       delete process.env.ANYTYPE_API_BASE_URL;
       new MCPProxy("test-proxy", createMockOpenApiSpec({ servers: undefined }));
       expectBaseUrl("http://127.0.0.1:31009");
+    });
+  });
+
+  describe("instructions", () => {
+    it("should pass instructions to Server when provided", () => {
+      MockServer.mockClear();
+
+      new MCPProxy("test-proxy", mockOpenApiSpec, "Available spaces:\n- MySpace (id: abc123)");
+
+      expect(MockServer).toHaveBeenCalledWith(
+        { name: "test-proxy", version: "1.0.0" },
+        expect.objectContaining({ instructions: "Available spaces:\n- MySpace (id: abc123)" }),
+      );
+    });
+
+    it("should not include instructions when not provided", () => {
+      MockServer.mockClear();
+
+      new MCPProxy("test-proxy", mockOpenApiSpec);
+
+      const serverOptions = MockServer.mock.calls[0][1];
+      expect(serverOptions).not.toHaveProperty("instructions");
     });
   });
 

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -33,8 +33,11 @@ export class MCPProxy {
   private tools: Record<string, NewToolDefinition>;
   private openApiLookup: Record<string, OpenAPIV3.OperationObject & { method: string; path: string }>;
 
-  constructor(name: string, openApiSpec: OpenAPIV3.Document) {
-    this.server = new Server({ name, version: "1.0.0" }, { capabilities: { tools: {} } });
+  constructor(name: string, openApiSpec: OpenAPIV3.Document, instructions?: string) {
+    this.server = new Server(
+      { name, version: "1.0.0" },
+      { capabilities: { tools: {} }, ...(instructions ? { instructions } : {}) },
+    );
     const { headers, baseUrl: credentialsBaseUrl } = loadCredentials();
     const baseUrl = determineBaseUrl(openApiSpec, credentialsBaseUrl);
     this.httpClient = new HttpClient(


### PR DESCRIPTION
## Summary
- Adds `prefetchSpaces()` to `init-server.ts` that fetches spaces from Anytype API at startup
- Passes the formatted space list as MCP `instructions` to the Server, so AI clients know available spaces without extra API calls
- Failure is non-fatal — server starts normally without instructions if the API is unreachable

## Test plan
- [x] All 123 existing tests pass
- [x] New tests verify instructions are passed/omitted correctly to the Server constructor
- [ ] Manual test with Anytype running to confirm instructions appear in MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)