### PR TITLE
feat: add batch get-objects tool (#8)

### DIFF
--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -322,11 +322,12 @@ describe("MCPProxy", () => {
       expect(mockExecute).toHaveBeenCalledTimes(1);
     });
 
-    it("should list custom tools including cache tools", async () => {
+    it("should list custom tools including cache and batch tools", async () => {
       const [listToolsHandler] = getHandlers(proxy);
       const result = await listToolsHandler();
 
       const toolNames = result.tools.map((t: Tool) => t.name);
+      expect(toolNames).toContain("API-batch-get-objects");
       expect(toolNames).toContain("API-cache-stats");
       expect(toolNames).toContain("API-get-cached-content");
     });
@@ -384,6 +385,154 @@ describe("MCPProxy", () => {
       });
       const data = JSON.parse(result.content[0].text);
       expect(data.status).toBe("miss");
+    });
+  });
+
+  describe("batch get-objects", () => {
+    const makeObjResponse = (id: string, name: string) => ({
+      data: {
+        object: {
+          id,
+          name,
+          type: { key: "page", name: "Page" },
+          layout: "basic",
+          snippet: `Preview of ${name}`,
+          markdown: `# ${name}\n\nFull body content...`,
+          properties: [{ key: "last_modified_date", date: "2025-06-01T12:00:00Z" }],
+        },
+      },
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+    });
+
+    beforeEach(() => {
+      (proxy as any).openApiLookup = {
+        "API-get-object": {
+          operationId: "get_object",
+          method: "get",
+          path: "/v1/spaces/{space_id}/objects/{object_id}",
+          responses: { "200": { description: "Success" } },
+        },
+      };
+    });
+
+    it("should fetch multiple objects and return summaries", async () => {
+      const mockExecute = HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>;
+      mockExecute
+        .mockResolvedValueOnce(makeObjResponse("obj-1", "First"))
+        .mockResolvedValueOnce(makeObjResponse("obj-2", "Second"));
+
+      const [, callToolHandler] = getHandlers(proxy);
+      const result = await callToolHandler({
+        params: {
+          name: "API-batch-get-objects",
+          arguments: { space_id: "space-1", object_ids: ["obj-1", "obj-2"] },
+        },
+      });
+
+      const summaries = JSON.parse(result.content[0].text);
+      expect(summaries).toHaveLength(2);
+      expect(summaries[0].name).toBe("First");
+      expect(summaries[0].object_id).toBe("obj-1");
+      expect(summaries[0].size_bytes).toBeGreaterThan(0);
+      expect(summaries[0].has_body).toBe(true);
+      expect(summaries[1].name).toBe("Second");
+      // Summaries should not contain full body content
+      expect(summaries[0]).not.toHaveProperty("markdown");
+    });
+
+    it("should use cache for already-cached objects", async () => {
+      const mockExecute = HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>;
+      mockExecute.mockResolvedValueOnce(makeObjResponse("obj-1", "First"));
+
+      const [, callToolHandler] = getHandlers(proxy);
+
+      // Pre-cache obj-1 via get-object
+      await callToolHandler({
+        params: { name: "API-get-object", arguments: { space_id: "space-1", object_id: "obj-1" } },
+      });
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+
+      // Batch fetch — obj-1 from cache, obj-2 from API
+      mockExecute.mockClear();
+      mockExecute.mockResolvedValueOnce(makeObjResponse("obj-2", "Second"));
+
+      const result = await callToolHandler({
+        params: {
+          name: "API-batch-get-objects",
+          arguments: { space_id: "space-1", object_ids: ["obj-1", "obj-2"] },
+        },
+      });
+
+      // Only obj-2 should have triggered an API call
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const summaries = JSON.parse(result.content[0].text);
+      expect(summaries).toHaveLength(2);
+    });
+
+    it("should handle errors for individual objects gracefully", async () => {
+      const mockExecute = HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>;
+      mockExecute
+        .mockResolvedValueOnce(makeObjResponse("obj-1", "Good"))
+        .mockRejectedValueOnce(new Error("Not found"));
+
+      const [, callToolHandler] = getHandlers(proxy);
+      const result = await callToolHandler({
+        params: {
+          name: "API-batch-get-objects",
+          arguments: { space_id: "space-1", object_ids: ["obj-1", "obj-bad"] },
+        },
+      });
+
+      const summaries = JSON.parse(result.content[0].text);
+      expect(summaries).toHaveLength(2);
+      expect(summaries[0].name).toBe("Good");
+      expect(summaries[1].status).toBe("error");
+      expect(summaries[1].object_id).toBe("obj-bad");
+    });
+
+    it("should reject empty object_ids", async () => {
+      const [, callToolHandler] = getHandlers(proxy);
+
+      await expect(
+        callToolHandler({
+          params: { name: "API-batch-get-objects", arguments: { space_id: "space-1", object_ids: [] } },
+        }),
+      ).rejects.toThrow("object_ids must be a non-empty array");
+    });
+
+    it("should reject more than 50 object_ids", async () => {
+      const [, callToolHandler] = getHandlers(proxy);
+      const ids = Array.from({ length: 51 }, (_, i) => `obj-${i}`);
+
+      await expect(
+        callToolHandler({
+          params: { name: "API-batch-get-objects", arguments: { space_id: "space-1", object_ids: ids } },
+        }),
+      ).rejects.toThrow("object_ids cannot exceed 50 items");
+    });
+
+    it("should populate cache for batch-fetched objects", async () => {
+      const mockExecute = HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>;
+      mockExecute.mockResolvedValueOnce(makeObjResponse("obj-1", "Cached"));
+
+      const [, callToolHandler] = getHandlers(proxy);
+      await callToolHandler({
+        params: {
+          name: "API-batch-get-objects",
+          arguments: { space_id: "space-1", object_ids: ["obj-1"] },
+        },
+      });
+
+      // Object should now be in cache — get-cached-content should work
+      const cachedResult = await callToolHandler({
+        params: {
+          name: "API-get-cached-content",
+          arguments: { space_id: "space-1", object_id: "obj-1" },
+        },
+      });
+      const data = JSON.parse(cachedResult.content[0].text);
+      expect(data.object.name).toBe("Cached");
     });
   });
 

--- a/src/mcp/cache.ts
+++ b/src/mcp/cache.ts
@@ -40,6 +40,7 @@ const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 export const CACHE_STATS_TOOL_NAME = "API-cache-stats";
 export const GET_CACHED_CONTENT_TOOL_NAME = "API-get-cached-content";
+export const BATCH_GET_OBJECTS_TOOL_NAME = "API-batch-get-objects";
 
 export const CACHE_STATS_TOOL: Tool = {
   name: CACHE_STATS_TOOL_NAME,
@@ -78,6 +79,30 @@ export const GET_CACHED_CONTENT_TOOL: Tool = {
       },
     },
     required: ["space_id", "object_id"],
+  },
+};
+
+export const BATCH_GET_OBJECTS_TOOL: Tool = {
+  name: BATCH_GET_OBJECTS_TOOL_NAME,
+  description:
+    "Fetch multiple objects by ID in a single call. Returns summaries (name, type, size, snippet) instead of full content " +
+    "to avoid bloating context. Use API-get-cached-content to retrieve full content for specific objects afterward. " +
+    "Maximum 50 objects per call.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      space_id: {
+        type: "string",
+        description: "The ID of the space containing the objects",
+      },
+      object_ids: {
+        type: "array",
+        items: { type: "string" },
+        description: "Array of object IDs to fetch",
+        maxItems: 50,
+      },
+    },
+    required: ["space_id", "object_ids"],
   },
 };
 

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -4,6 +4,8 @@ import { CallToolRequestSchema, ListToolsRequestSchema, Tool } from "@modelconte
 import { JSONSchema7 as IJsonSchema } from "json-schema";
 import { OpenAPIV3 } from "openapi-types";
 import {
+  BATCH_GET_OBJECTS_TOOL,
+  BATCH_GET_OBJECTS_TOOL_NAME,
   CACHE_STATS_TOOL,
   CACHE_STATS_TOOL_NAME,
   GET_CACHED_CONTENT_TOOL,
@@ -76,6 +78,7 @@ export class MCPProxy {
       });
 
       // Add custom tools
+      tools.push(BATCH_GET_OBJECTS_TOOL);
       tools.push(CACHE_STATS_TOOL);
       tools.push(GET_CACHED_CONTENT_TOOL);
 
@@ -88,6 +91,9 @@ export class MCPProxy {
       const { name, arguments: params } = request.params;
 
       // Handle custom tools
+      if (name === BATCH_GET_OBJECTS_TOOL_NAME) {
+        return this.handleBatchGetObjects(params);
+      }
       if (name === CACHE_STATS_TOOL_NAME) {
         return this.handleCacheStats(params);
       }
@@ -195,6 +201,76 @@ export class MCPProxy {
 
     return {
       content: [{ type: "text", text: JSON.stringify(response.data) }],
+    };
+  }
+
+  private async handleBatchGetObjects(
+    params: Record<string, unknown> | undefined,
+  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    const spaceId = params?.space_id as string | undefined;
+    const objectIds = params?.object_ids as string[] | undefined;
+
+    if (!spaceId) {
+      throw new Error("space_id is required");
+    }
+    if (!objectIds || !Array.isArray(objectIds) || objectIds.length === 0) {
+      throw new Error("object_ids must be a non-empty array");
+    }
+    if (objectIds.length > 50) {
+      throw new Error("object_ids cannot exceed 50 items");
+    }
+
+    const operation = this.findOperation("API-get-object");
+    if (!operation) {
+      throw new Error("get-object operation not found in OpenAPI spec");
+    }
+
+    const CONCURRENCY = 10;
+    const summaries: Array<
+      | import("./cache").ObjectSummary
+      | { object_id: string; status: "error"; error: string }
+    > = [];
+
+    for (let i = 0; i < objectIds.length; i += CONCURRENCY) {
+      const batch = objectIds.slice(i, i + CONCURRENCY);
+      const settled = await Promise.allSettled(
+        batch.map(async (objectId) => {
+          // Check cache first
+          const cached = this.objectCache.get(spaceId, objectId);
+          if (cached) {
+            console.error(`Batch: cache hit for ${spaceId}:${objectId}`);
+            return cached;
+          }
+
+          // Fetch from API and cache
+          const response = await this.httpClient.executeOperation(operation, {
+            space_id: spaceId,
+            object_id: objectId,
+          });
+          const data = response.data as Record<string, unknown>;
+          this.objectCache.set(spaceId, objectId, data);
+          return this.objectCache.get(spaceId, objectId)!;
+        }),
+      );
+
+      for (let j = 0; j < settled.length; j++) {
+        const result = settled[j];
+        const objectId = batch[j];
+        if (result.status === "fulfilled") {
+          summaries.push(this.objectCache.buildSummary(result.value));
+        } else {
+          const err = result.reason;
+          const errorMsg =
+            err instanceof HttpClientError
+              ? JSON.stringify(err.data?.response?.data ?? err.data ?? err.message)
+              : String(err);
+          summaries.push({ object_id: objectId, status: "error", error: errorMsg });
+        }
+      }
+    }
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(summaries) }],
     };
   }
 


### PR DESCRIPTION
## Summary
- New `API-batch-get-objects` tool: fetches up to 50 objects in parallel (concurrency 10)
- Returns **summaries** (name, type, size, snippet, has_body) instead of full content to avoid bloating AI context
- All fetched objects are cached — agent uses `API-get-cached-content` to drill down into specific objects
- Cache hits skip API calls for already-cached objects

## Dependencies
- Based on `feat/cache-get-object` (#15) — merge that first

## Test plan
- [x] All 151 tests pass (6 new batch tests)
- [x] TypeScript typecheck passes
- [ ] Manual test: batch-fetch multiple known objects and verify summaries
- [ ] Manual test: use API-get-cached-content after batch to retrieve full object

🤖 Generated with [Claude Code](https://claude.com/claude-code)