### PR TITLE
feat: implement filter support for search endpoints (#9)

### DIFF
--- a/src/openapi/__tests__/parser-filters.test.ts
+++ b/src/openapi/__tests__/parser-filters.test.ts
@@ -1,0 +1,245 @@
+import { JSONSchema7 as IJsonSchema } from "json-schema";
+import { OpenAPIV3 } from "openapi-types";
+import { describe, expect, it } from "vitest";
+import { OpenAPIToMCPConverter } from "../parser";
+
+describe("Filter support", () => {
+  describe("FilterExpression schema resolution", () => {
+    it("should resolve FilterExpression $ref to a proper schema instead of empty object", () => {
+      const converter = new OpenAPIToMCPConverter({
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0.0" },
+        paths: {},
+        components: {
+          schemas: {
+            FilterExpression: {
+              type: "object",
+              properties: {
+                operator: { $ref: "#/components/schemas/FilterOperator" },
+                conditions: { type: "array", items: { $ref: "#/components/schemas/FilterItem" } },
+                filters: { type: "array", items: { $ref: "#/components/schemas/FilterExpression" } },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document);
+
+      const schema = converter.convertOpenApiSchemaToJsonSchema(
+        { $ref: "#/components/schemas/FilterExpression" },
+        new Set(),
+      );
+
+      // Should NOT be an empty object
+      expect(schema).not.toEqual({});
+      expect(schema.type).toBe("object");
+      expect(schema.properties).toBeDefined();
+    });
+
+    it("should produce FilterExpression with operator, conditions, and filters fields", () => {
+      const converter = new OpenAPIToMCPConverter({
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0.0" },
+        paths: {},
+      } as OpenAPIV3.Document);
+
+      const schema = converter.convertOpenApiSchemaToJsonSchema(
+        { $ref: "#/components/schemas/FilterExpression" },
+        new Set(),
+      );
+
+      const props = schema.properties as Record<string, IJsonSchema>;
+      expect(props).toBeDefined();
+
+      // operator
+      expect(props.operator).toBeDefined();
+      expect(props.operator.enum).toEqual(["and", "or"]);
+
+      // conditions
+      expect(props.conditions).toBeDefined();
+      expect(props.conditions.type).toBe("array");
+      const conditionItem = props.conditions.items as IJsonSchema;
+      expect(conditionItem.type).toBe("object");
+
+      // filters (nested)
+      expect(props.filters).toBeDefined();
+      expect(props.filters.type).toBe("array");
+    });
+
+    it("should include all filter condition value fields in FilterItem", () => {
+      const converter = new OpenAPIToMCPConverter({
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0.0" },
+        paths: {},
+      } as OpenAPIV3.Document);
+
+      const schema = converter.convertOpenApiSchemaToJsonSchema(
+        { $ref: "#/components/schemas/FilterExpression" },
+        new Set(),
+      );
+
+      const conditionItem = (schema.properties as Record<string, IJsonSchema>).conditions.items as IJsonSchema;
+      const itemProps = conditionItem.properties as Record<string, IJsonSchema>;
+
+      // Required fields
+      expect(itemProps.property_key).toBeDefined();
+      expect(itemProps.property_key.type).toBe("string");
+      expect(itemProps.condition).toBeDefined();
+      expect(itemProps.condition.enum).toBeDefined();
+      expect((itemProps.condition.enum as string[]).length).toBeGreaterThanOrEqual(17);
+
+      // All value type fields
+      expect(itemProps.text?.type).toBe("string");
+      expect(itemProps.number?.type).toBe("number");
+      expect(itemProps.select?.type).toBe("string");
+      expect(itemProps.multi_select?.type).toBe("array");
+      expect(itemProps.date?.type).toBe("string");
+      expect(itemProps.checkbox?.type).toBe("boolean");
+      expect(itemProps.url?.type).toBe("string");
+      expect(itemProps.email?.type).toBe("string");
+      expect(itemProps.phone?.type).toBe("string");
+      expect(itemProps.objects?.type).toBe("array");
+      expect(itemProps.files?.type).toBe("array");
+    });
+
+    it("should include all 17 filter condition operators", () => {
+      const converter = new OpenAPIToMCPConverter({
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0.0" },
+        paths: {},
+      } as OpenAPIV3.Document);
+
+      const schema = converter.convertOpenApiSchemaToJsonSchema(
+        { $ref: "#/components/schemas/FilterExpression" },
+        new Set(),
+      );
+
+      const conditionItem = (schema.properties as Record<string, IJsonSchema>).conditions.items as IJsonSchema;
+      const conditionEnum = (conditionItem.properties as Record<string, IJsonSchema>).condition.enum as string[];
+
+      const expectedConditions = [
+        "equal",
+        "not_equal",
+        "greater",
+        "less",
+        "greater_or_equal",
+        "less_or_equal",
+        "like",
+        "not_like",
+        "in",
+        "not_in",
+        "empty",
+        "not_empty",
+        "all_in",
+        "not_all_in",
+        "exact_in",
+        "not_exact_in",
+        "exists",
+      ];
+
+      for (const cond of expectedConditions) {
+        expect(conditionEnum).toContain(cond);
+      }
+    });
+  });
+
+  describe("search tools include filters", () => {
+    const createSpecWithSearch = (): OpenAPIV3.Document =>
+      ({
+        openapi: "3.0.0",
+        info: { title: "Anytype API", version: "1.0.0" },
+        paths: {
+          "/v1/spaces/{space_id}/search": {
+            post: {
+              operationId: "search_space",
+              summary: "Search objects in space",
+              parameters: [
+                { name: "space_id", in: "path", required: true, schema: { type: "string" } },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        query: { type: "string" },
+                        filters: { $ref: "#/components/schemas/FilterExpression" },
+                        sorts: { type: "array", items: { type: "object" } },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            FilterExpression: {
+              type: "object",
+              properties: {
+                operator: { $ref: "#/components/schemas/FilterOperator" },
+                conditions: { type: "array", items: { $ref: "#/components/schemas/FilterItem" } },
+                filters: { type: "array", items: { $ref: "#/components/schemas/FilterExpression" } },
+              },
+            },
+          },
+        },
+      }) as OpenAPIV3.Document;
+
+    it("should include filters property in search tool input schema", () => {
+      const converter = new OpenAPIToMCPConverter(createSpecWithSearch());
+      const { tools } = converter.convertToMCPTools();
+
+      const searchTool = tools["API"]?.methods.find((m) => m.name.includes("search"));
+      expect(searchTool).toBeDefined();
+
+      const inputProps = searchTool!.inputSchema.properties as Record<string, IJsonSchema>;
+      expect(inputProps.filters).toBeDefined();
+      expect(inputProps.filters.type).toBe("object");
+      expect(inputProps.filters.properties).toBeDefined();
+    });
+
+    it("should not strip filters from required array", () => {
+      const spec = createSpecWithSearch();
+      // Make filters required in the spec
+      const bodySchema = (spec.paths["/v1/spaces/{space_id}/search"] as any).post.requestBody.content[
+        "application/json"
+      ].schema;
+      bodySchema.required = ["query", "filters"];
+
+      const converter = new OpenAPIToMCPConverter(spec);
+      const { tools } = converter.convertToMCPTools();
+
+      const searchTool = tools["API"]?.methods.find((m) => m.name.includes("search"));
+      expect(searchTool!.inputSchema.required).toContain("filters");
+    });
+  });
+
+  describe("non-filter tools remain unaffected", () => {
+    it("should not add filters to operations without FilterExpression", () => {
+      const converter = new OpenAPIToMCPConverter({
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0.0" },
+        paths: {
+          "/v1/spaces/{space_id}/objects/{object_id}": {
+            get: {
+              operationId: "get_object",
+              parameters: [
+                { name: "space_id", in: "path", required: true, schema: { type: "string" } },
+                { name: "object_id", in: "path", required: true, schema: { type: "string" } },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      } as OpenAPIV3.Document);
+
+      const { tools } = converter.convertToMCPTools();
+      const getTool = tools["API"]?.methods[0];
+      const inputProps = getTool!.inputSchema.properties as Record<string, IJsonSchema>;
+
+      expect(inputProps.filters).toBeUndefined();
+    });
+  });
+});

--- a/src/openapi/parser.ts
+++ b/src/openapi/parser.ts
@@ -56,9 +56,8 @@ export class OpenAPIToMCPConverter {
   ): IJsonSchema {
     if ("$ref" in schema) {
       const ref = schema.$ref;
-      // TODO: Add support for filters
       if (ref === "#/components/schemas/FilterExpression") {
-        return {};
+        return buildFilterExpressionSchema();
       }
       if (!resolveRefs) {
         if (ref.startsWith("#/components/schemas/")) {
@@ -460,12 +459,10 @@ export class OpenAPIToMCPConverter {
           );
           if (bodySchema.type === "object" && bodySchema.properties) {
             for (const [name, propSchema] of Object.entries(bodySchema.properties)) {
-              // TODO: Add support for filters
-              if (name === "filters") continue;
               schema.properties![name] = propSchema;
             }
             if (bodySchema.required) {
-              schema.required!.push(...bodySchema.required.filter((r) => r !== "filters"));
+              schema.required!.push(...bodySchema.required);
             }
           }
         }
@@ -589,12 +586,10 @@ export class OpenAPIToMCPConverter {
           );
           if (formSchema.type === "object" && formSchema.properties) {
             for (const [name, propSchema] of Object.entries(formSchema.properties)) {
-              // TODO: Add support for filters
-              if (name === "filters") continue;
               inputSchema.properties![name] = propSchema;
             }
             if (formSchema.required) {
-              inputSchema.required!.push(...formSchema.required!.filter((r) => r !== "filters"));
+              inputSchema.required!.push(...formSchema.required!);
             }
           }
         }
@@ -608,12 +603,10 @@ export class OpenAPIToMCPConverter {
           // Merge body schema into the inputSchema's properties
           if (bodySchema.type === "object" && bodySchema.properties) {
             for (const [name, propSchema] of Object.entries(bodySchema.properties)) {
-              // TODO: Add support for filters
-              if (name === "filters") continue;
               inputSchema.properties![name] = propSchema;
             }
             if (bodySchema.required) {
-              inputSchema.required!.push(...bodySchema.required!.filter((r) => r !== "filters"));
+              inputSchema.required!.push(...bodySchema.required!);
             }
           } else {
             // If the request body is not an object, just put it under "body"
@@ -715,4 +708,146 @@ export class OpenAPIToMCPConverter {
     this.nameCounter += 1;
     return this.nameCounter.toString().padStart(4, "0");
   }
+}
+
+const FILTER_CONDITIONS = [
+  "equal",
+  "not_equal",
+  "greater",
+  "less",
+  "greater_or_equal",
+  "less_or_equal",
+  "like",
+  "not_like",
+  "in",
+  "not_in",
+  "empty",
+  "not_empty",
+  "all_in",
+  "not_all_in",
+  "exact_in",
+  "not_exact_in",
+  "exists",
+] as const;
+
+/**
+ * Builds a flattened JSON Schema for FilterExpression, matching the pattern
+ * used for PropertyValue and Icon (hardcoded schema instead of $ref resolution).
+ *
+ * FilterItem is represented as a flat object with all possible value fields,
+ * so AI agents can construct filters without needing to pick a specific subtype.
+ */
+function buildFilterExpressionSchema(): IJsonSchema {
+  const filterItemSchema: IJsonSchema = {
+    type: "object",
+    description: "A filter condition. Set property_key, condition, and the appropriate value field for the property type.",
+    properties: {
+      property_key: {
+        type: "string",
+        description: "The property key to filter on",
+        examples: ["name", "description", "status", "last_modified_date"],
+      },
+      condition: {
+        type: "string",
+        description: "The filter condition operator",
+        enum: [...FILTER_CONDITIONS],
+      },
+      text: {
+        type: "string",
+        description: "Text value (for text properties). Use with like/not_like for substring match.",
+        examples: ["Some text..."],
+      },
+      number: {
+        type: "number",
+        description: "Number value (for number properties)",
+        examples: [42],
+      },
+      select: {
+        type: "string",
+        description: "Tag ID (for select properties, single selection)",
+        examples: ["tag_id"],
+      },
+      multi_select: {
+        type: "array",
+        description: "Tag IDs (for multi_select properties)",
+        items: { type: "string" },
+        examples: [["tag_id_1", "tag_id_2"]],
+      },
+      date: {
+        type: "string",
+        description: "Date value in RFC3339 (2006-01-02T15:04:05Z) or date-only (2006-01-02) format",
+        examples: ["2025-01-15T00:00:00Z"],
+      },
+      checkbox: {
+        type: "boolean",
+        description: "Checkbox value (for checkbox properties)",
+        examples: [true],
+      },
+      url: {
+        type: "string",
+        description: "URL value (for url properties)",
+        examples: ["https://example.com"],
+      },
+      email: {
+        type: "string",
+        description: "Email value (for email properties)",
+        examples: ["user@example.com"],
+      },
+      phone: {
+        type: "string",
+        description: "Phone value (for phone properties)",
+        examples: ["+1234567890"],
+      },
+      objects: {
+        type: "array",
+        description: "Object IDs (for object/relation properties)",
+        items: { type: "string" },
+        examples: [["object_id"]],
+      },
+      files: {
+        type: "array",
+        description: "File IDs (for file properties)",
+        items: { type: "string" },
+        examples: [["file_id"]],
+      },
+    },
+    additionalProperties: true,
+  };
+
+  return {
+    type: "object",
+    description: "Expression filter with nested AND/OR conditions",
+    properties: {
+      operator: {
+        type: "string",
+        description: "Logical operator for combining filters",
+        enum: ["and", "or"],
+      },
+      conditions: {
+        type: "array",
+        description: "List of filter conditions",
+        items: filterItemSchema,
+      },
+      filters: {
+        type: "array",
+        description: "Nested filter expressions for complex logic (one level of nesting)",
+        items: {
+          type: "object",
+          description: "Nested filter expression",
+          properties: {
+            operator: {
+              type: "string",
+              enum: ["and", "or"],
+            },
+            conditions: {
+              type: "array",
+              items: filterItemSchema,
+            },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    additionalProperties: true,
+  };
 }


### PR DESCRIPTION
## Summary
- Replaces the empty `{}` FilterExpression schema with a hardcoded flattened schema (same pattern as PropertyValue and Icon)
- Removes all 6 filter-stripping lines that blocked `filters` from search tool input schemas
- FilterItem is a flat object: `property_key` + `condition` (17 operators) + value field for the property type
- Supports one level of nested FilterExpression for complex AND/OR logic
- Affected endpoints: `search_space` and `search_global`

## Example usage
```json
{
  "query": "",
  "filters": {
    "operator": "and",
    "conditions": [
      { "property_key": "name", "condition": "like", "text": "meeting" },
      { "property_key": "last_modified_date", "condition": "greater", "date": "2025-01-01" }
    ]
  }
}
```

## Test plan
- [x] All 128 tests pass (5 new filter tests + no regressions)
- [x] TypeScript typecheck passes
- [ ] Manual test: call API-search-space with a filter to verify it works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)