### PR TITLE
feat: improve update-object workflow

### DIFF
--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -280,7 +280,7 @@ describe("MCPProxy", () => {
       expect(JSON.parse(result2.content[0].text)).toEqual(mockObjectResponse.data);
     });
 
-    it("should invalidate cache on update-object", async () => {
+    it("should write-through cache on update-object", async () => {
       const mockExecute = HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>;
       mockExecute.mockResolvedValue(mockObjectResponse);
 
@@ -290,15 +290,29 @@ describe("MCPProxy", () => {
       // Cache the object
       await callToolHandler({ params: { name: "API-get-object", arguments: args } });
 
-      // Update it
-      mockExecute.mockResolvedValue({ data: { ok: true }, status: 200, headers: new Headers() });
+      // Update it — API returns the updated object
+      const updatedResponse = {
+        data: {
+          object: {
+            id: "obj-1",
+            name: "Updated Object",
+            type: { key: "page", name: "Page" },
+            properties: [{ key: "last_modified_date", date: "2025-06-02T12:00:00Z" }],
+            markdown: "# Updated",
+          },
+        },
+        status: 200,
+        headers: new Headers(),
+      };
+      mockExecute.mockResolvedValue(updatedResponse);
       await callToolHandler({ params: { name: "API-update-object", arguments: args } });
 
-      // Next get should fetch from API again
+      // Next get should return from cache (no API call) with updated data
       mockExecute.mockClear();
-      mockExecute.mockResolvedValue(mockObjectResponse);
-      await callToolHandler({ params: { name: "API-get-object", arguments: args } });
-      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const result = await callToolHandler({ params: { name: "API-get-object", arguments: args } });
+      expect(mockExecute).not.toHaveBeenCalled();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.object.name).toBe("Updated Object");
     });
 
     it("should invalidate cache on delete-object", async () => {
@@ -328,6 +342,7 @@ describe("MCPProxy", () => {
 
       const toolNames = result.tools.map((t: Tool) => t.name);
       expect(toolNames).toContain("API-batch-get-objects");
+      expect(toolNames).toContain("API-batch-update-objects");
       expect(toolNames).toContain("API-cache-stats");
       expect(toolNames).toContain("API-get-cached-content");
     });
@@ -533,6 +548,140 @@ describe("MCPProxy", () => {
       });
       const data = JSON.parse(cachedResult.content[0].text);
       expect(data.object.name).toBe("Cached");
+    });
+  });
+
+  describe("batch update-objects", () => {
+    const makeUpdatedObjResponse = (id: string, name: string) => ({
+      data: {
+        object: {
+          id,
+          name,
+          type: { key: "page", name: "Page" },
+          layout: "basic",
+          snippet: `Updated ${name}`,
+          markdown: `# ${name}\n\nUpdated content`,
+          properties: [{ key: "last_modified_date", date: "2025-06-02T12:00:00Z" }],
+        },
+      },
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+    });
+
+    beforeEach(() => {
+      (proxy as any).openApiLookup = {
+        "API-update-object": {
+          operationId: "update_object",
+          method: "patch",
+          path: "/v1/spaces/{space_id}/objects/{object_id}",
+          responses: { "200": { description: "Success" } },
+        },
+        "API-get-object": {
+          operationId: "get_object",
+          method: "get",
+          path: "/v1/spaces/{space_id}/objects/{object_id}",
+          responses: { "200": { description: "Success" } },
+        },
+      };
+    });
+
+    it("should update multiple objects and return summaries", async () => {
+      const mockExecute = HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>;
+      mockExecute
+        .mockResolvedValueOnce(makeUpdatedObjResponse("obj-1", "Updated First"))
+        .mockResolvedValueOnce(makeUpdatedObjResponse("obj-2", "Updated Second"));
+
+      const [, callToolHandler] = getHandlers(proxy);
+      const result = await callToolHandler({
+        params: {
+          name: "API-batch-update-objects",
+          arguments: {
+            space_id: "space-1",
+            updates: [
+              { object_id: "obj-1", name: "Updated First" },
+              { object_id: "obj-2", markdown: "New content" },
+            ],
+          },
+        },
+      });
+
+      const summaries = JSON.parse(result.content[0].text);
+      expect(summaries).toHaveLength(2);
+      expect(summaries[0].name).toBe("Updated First");
+      expect(summaries[1].name).toBe("Updated Second");
+    });
+
+    it("should write-through cache for batch-updated objects", async () => {
+      const mockExecute = HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>;
+      mockExecute.mockResolvedValueOnce(makeUpdatedObjResponse("obj-1", "Batch Updated"));
+
+      const [, callToolHandler] = getHandlers(proxy);
+      await callToolHandler({
+        params: {
+          name: "API-batch-update-objects",
+          arguments: {
+            space_id: "space-1",
+            updates: [{ object_id: "obj-1", name: "Batch Updated" }],
+          },
+        },
+      });
+
+      // Object should be in cache — get from cache without API call
+      mockExecute.mockClear();
+      const cachedResult = await callToolHandler({
+        params: { name: "API-get-object", arguments: { space_id: "space-1", object_id: "obj-1" } },
+      });
+      expect(mockExecute).not.toHaveBeenCalled();
+      const data = JSON.parse(cachedResult.content[0].text);
+      expect(data.object.name).toBe("Batch Updated");
+    });
+
+    it("should handle individual update errors gracefully", async () => {
+      const mockExecute = HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>;
+      mockExecute
+        .mockResolvedValueOnce(makeUpdatedObjResponse("obj-1", "Good"))
+        .mockRejectedValueOnce(new Error("Not found"));
+
+      const [, callToolHandler] = getHandlers(proxy);
+      const result = await callToolHandler({
+        params: {
+          name: "API-batch-update-objects",
+          arguments: {
+            space_id: "space-1",
+            updates: [
+              { object_id: "obj-1", name: "Good" },
+              { object_id: "obj-bad", name: "Will fail" },
+            ],
+          },
+        },
+      });
+
+      const summaries = JSON.parse(result.content[0].text);
+      expect(summaries).toHaveLength(2);
+      expect(summaries[0].name).toBe("Good");
+      expect(summaries[1].status).toBe("error");
+      expect(summaries[1].object_id).toBe("obj-bad");
+    });
+
+    it("should reject empty updates array", async () => {
+      const [, callToolHandler] = getHandlers(proxy);
+
+      await expect(
+        callToolHandler({
+          params: { name: "API-batch-update-objects", arguments: { space_id: "space-1", updates: [] } },
+        }),
+      ).rejects.toThrow("updates must be a non-empty array");
+    });
+
+    it("should reject more than 20 updates", async () => {
+      const [, callToolHandler] = getHandlers(proxy);
+      const updates = Array.from({ length: 21 }, (_, i) => ({ object_id: `obj-${i}`, name: `Name ${i}` }));
+
+      await expect(
+        callToolHandler({
+          params: { name: "API-batch-update-objects", arguments: { space_id: "space-1", updates } },
+        }),
+      ).rejects.toThrow("updates cannot exceed 20 items");
     });
   });
 

--- a/src/mcp/cache.ts
+++ b/src/mcp/cache.ts
@@ -82,6 +82,47 @@ export const GET_CACHED_CONTENT_TOOL: Tool = {
   },
 };
 
+export const BATCH_UPDATE_OBJECTS_TOOL_NAME = "API-batch-update-objects";
+
+export const BATCH_UPDATE_OBJECTS_TOOL: Tool = {
+  name: BATCH_UPDATE_OBJECTS_TOOL_NAME,
+  description:
+    "Update multiple objects in a single call. Each update specifies an object_id and the fields to change " +
+    "(name, markdown, icon, properties, type_key). Returns summaries of all updated objects. " +
+    "Maximum 20 objects per call.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      space_id: {
+        type: "string",
+        description: "The ID of the space containing the objects",
+      },
+      updates: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            object_id: { type: "string", description: "The ID of the object to update" },
+            name: { type: "string", description: "New name for the object" },
+            markdown: { type: "string", description: "New body content" },
+            icon: { type: "object", description: "New icon (emoji format)" },
+            properties: {
+              type: "array",
+              items: { type: "object" },
+              description: "Properties to set",
+            },
+            type_key: { type: "string", description: "New type key" },
+          },
+          required: ["object_id"],
+        },
+        description: "Array of update payloads, each with object_id and fields to change",
+        maxItems: 20,
+      },
+    },
+    required: ["space_id", "updates"],
+  },
+};
+
 export const BATCH_GET_OBJECTS_TOOL: Tool = {
   name: BATCH_GET_OBJECTS_TOOL_NAME,
   description:

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -6,6 +6,8 @@ import { OpenAPIV3 } from "openapi-types";
 import {
   BATCH_GET_OBJECTS_TOOL,
   BATCH_GET_OBJECTS_TOOL_NAME,
+  BATCH_UPDATE_OBJECTS_TOOL,
+  BATCH_UPDATE_OBJECTS_TOOL_NAME,
   CACHE_STATS_TOOL,
   CACHE_STATS_TOOL_NAME,
   GET_CACHED_CONTENT_TOOL,
@@ -79,6 +81,7 @@ export class MCPProxy {
 
       // Add custom tools
       tools.push(BATCH_GET_OBJECTS_TOOL);
+      tools.push(BATCH_UPDATE_OBJECTS_TOOL);
       tools.push(CACHE_STATS_TOOL);
       tools.push(GET_CACHED_CONTENT_TOOL);
 
@@ -93,6 +96,9 @@ export class MCPProxy {
       // Handle custom tools
       if (name === BATCH_GET_OBJECTS_TOOL_NAME) {
         return this.handleBatchGetObjects(params);
+      }
+      if (name === BATCH_UPDATE_OBJECTS_TOOL_NAME) {
+        return this.handleBatchUpdateObjects(params);
       }
       if (name === CACHE_STATS_TOOL_NAME) {
         return this.handleCacheStats(params);
@@ -117,13 +123,21 @@ export class MCPProxy {
         // Execute the operation
         const response = await this.httpClient.executeOperation(operation, params);
 
-        // Post-operation cache invalidation
-        if (name === "API-update-object" || name === "API-delete-object") {
+        // Post-operation cache handling
+        if (name === "API-update-object") {
+          const spaceId = params?.space_id as string;
+          const objectId = params?.object_id as string;
+          if (spaceId && objectId && response.data) {
+            // Write-through: cache the updated object from the response
+            this.objectCache.set(spaceId, objectId, response.data as Record<string, unknown>);
+            console.error(`Cache write-through for ${spaceId}:${objectId} after update`);
+          }
+        } else if (name === "API-delete-object") {
           const spaceId = params?.space_id as string;
           const objectId = params?.object_id as string;
           if (spaceId && objectId) {
             this.objectCache.invalidate(spaceId, objectId);
-            console.error(`Cache invalidated for ${spaceId}:${objectId} after ${name}`);
+            console.error(`Cache invalidated for ${spaceId}:${objectId} after delete`);
           }
         }
 
@@ -271,6 +285,76 @@ export class MCPProxy {
 
     return {
       content: [{ type: "text", text: JSON.stringify(summaries) }],
+    };
+  }
+
+  private async handleBatchUpdateObjects(
+    params: Record<string, unknown> | undefined,
+  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    const spaceId = params?.space_id as string | undefined;
+    const updates = params?.updates as Array<Record<string, unknown>> | undefined;
+
+    if (!spaceId) {
+      throw new Error("space_id is required");
+    }
+    if (!updates || !Array.isArray(updates) || updates.length === 0) {
+      throw new Error("updates must be a non-empty array");
+    }
+    if (updates.length > 20) {
+      throw new Error("updates cannot exceed 20 items");
+    }
+
+    const operation = this.findOperation("API-update-object");
+    if (!operation) {
+      throw new Error("update-object operation not found in OpenAPI spec");
+    }
+
+    const CONCURRENCY = 5;
+    const results: Array<
+      | import("./cache").ObjectSummary
+      | { object_id: string; status: "error"; error: string }
+    > = [];
+
+    for (let i = 0; i < updates.length; i += CONCURRENCY) {
+      const batch = updates.slice(i, i + CONCURRENCY);
+      const settled = await Promise.allSettled(
+        batch.map(async (update) => {
+          const objectId = update.object_id as string;
+          if (!objectId) throw new Error("object_id is required in each update");
+
+          // Build params: space_id + object_id + update fields
+          const { object_id, ...updateFields } = update;
+          const callParams = { space_id: spaceId, object_id: objectId, ...updateFields };
+
+          const response = await this.httpClient.executeOperation(operation, callParams);
+          const data = response.data as Record<string, unknown>;
+
+          // Write-through: cache the updated object
+          this.objectCache.set(spaceId, objectId, data);
+          console.error(`Batch update: write-through cache for ${spaceId}:${objectId}`);
+
+          return this.objectCache.get(spaceId, objectId)!;
+        }),
+      );
+
+      for (let j = 0; j < settled.length; j++) {
+        const result = settled[j];
+        const objectId = batch[j].object_id as string;
+        if (result.status === "fulfilled") {
+          results.push(this.objectCache.buildSummary(result.value));
+        } else {
+          const err = result.reason;
+          const errorMsg =
+            err instanceof HttpClientError
+              ? JSON.stringify(err.data?.response?.data ?? err.data ?? err.message)
+              : String(err);
+          results.push({ object_id: objectId, status: "error", error: errorMsg });
+        }
+      }
+    }
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(results) }],
     };
   }
 


### PR DESCRIPTION
## Summary
- **Write-through cache**: `update-object` now caches the API response instead of invalidating, eliminating the re-fetch on the next `get-object` call
- **Batch update tool**: New `API-batch-update-objects` custom tool fans out updates with concurrency 5, max 20 items, returns summaries with write-through cache
- **Response-aware staleness**: Updated objects get their `last_modified_date` tracked from the response

Closes #12

## Test plan
- [x] 32 proxy tests pass (5 new for batch update, 1 updated for write-through)
- [x] Full suite: 165 tests pass across 13 files
- [ ] Manual test with running Anytype instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)